### PR TITLE
Notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
+        "@microsoft/tsdoc": "^0.15.1",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-alert-dialog": "1.1.4",
         "@radix-ui/react-aspect-ratio": "1.1.1",
@@ -44,9 +45,10 @@
         "date-fns": "4.1.0",
         "embla-carousel-react": "8.5.1",
         "input-otp": "1.4.1",
-        "lucide-react": "^0.454.0",
+        "lucide-react": "^0.553.0",
         "next": "^16.0.0",
         "next-themes": "^0.4.6",
+        "primereact": "^10.9.7",
         "react": "^19.2.0",
         "react-day-picker": "9.8.0",
         "react-dom": "^19.2.0",
@@ -1092,6 +1094,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -3010,7 +3018,6 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3026,6 +3033,15 @@
       "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6693,12 +6709,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.454.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.454.0.tgz",
-      "integrity": "sha512-hw7zMDwykCLnEzgncEEjHeA6+45aeEzRYuKHuyRSOPkhko+J3ySGjGIzu+mmMfDFG1vazHepMaYFYHbTFAZAAQ==",
+      "version": "0.553.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.553.0.tgz",
+      "integrity": "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -7224,6 +7240,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/primereact": {
+      "version": "10.9.7",
+      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.9.7.tgz",
+      "integrity": "sha512-Ap/lg9GGaS8Pq7IIlzguuG3qlaU6PYF6E0cCRo0rnWauRw/SQGvfreSVIIxqEhtR6xqlf7OV759lyvVOvBzmsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-transition-group": "^4.4.1",
+        "react-transition-group": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {

--- a/src/app/(authed)/layout.tsx
+++ b/src/app/(authed)/layout.tsx
@@ -2,105 +2,43 @@
 
 import React, { useState } from "react";
 import { Sidebar } from "./sidebar";
-import { Menu, Bell } from "lucide-react";
-import { NotificationDrawer } from "@/components/ui/notificationDrawer";
-import { useRouter } from "next/navigation";
-import type { Notification } from "@/lib/types";
+import { Menu } from "lucide-react";
+import { NotificationBell } from "@/src/components/ui/notificationBell";
 
 type SurveyLayoutProps = {
-  children: React.ReactNode;
-};
-
-const mockNotifications: Notification[] = [
-  {
-    id: 1,
-    message: "You were mentioned in RFC-123",
-    createdAt: "2025-11-27T10:00:00Z",
-    read: false,
-    targetUrl: "/rfc/123",
-  },
-  {
-    id: 2,
-    message: "RFC-234 was approved",
-    createdAt: "2025-11-27T09:30:00Z",
-    read: true,
-    targetUrl: "/rfc/234",
-  },
-  {
-    id: 3,
-    message: "ADR-56 was updated",
-    createdAt: "2025-11-27T08:15:00Z",
-    read: true,
-    targetUrl: "/adr/56",
-  },
-];
+  children: React.ReactNode
+}
 
 export default function SurveyLayout({ children }: SurveyLayoutProps) {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [notificationsOpen, setNotificationsOpen] = useState(false);
-  const [notifications, setNotifications] =
-    useState<Notification[]>(mockNotifications);
-
-  const router = useRouter();
-
-  const hasUnread = notifications.some((n) => !n.read);
-
-  const handleNotificationClick = (notification: Notification) => {
-    setNotifications((prev) =>
-      prev.map((n) =>
-        n.id === notification.id ? { ...n, read: true } : n
-      )
-    );
-
-    router.push(notification.targetUrl);
-
-    setNotificationsOpen(false);
-  };
+  const [sidebarOpen, setSidebarOpen] = useState(false)
 
   return (
-    <div className="flex h-screen bg-white">
-      {}
+    <div className="flex h-screen bg-gray-50">
       <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
-      {}
       <div className="flex-1 flex flex-col relative">
-        {}
-        <button
-          className="absolute top-4 left-4 z-50 md:hidden bg-white rounded-full p-2 shadow border border-gray-200"
-          onClick={() => setSidebarOpen(true)}
-          aria-label="Open sidebar"
-        >
-          <Menu className="h-6 w-6 text-gray-700" />
-        </button>
 
-        {}
-        <header className="hidden md:flex items-center justify-end px-6 py-4">
+        {/* Zona superior izquierda: menú (móvil) + campanita */}
+        <div className="absolute top-4 right-4 z-50 flex items-center gap-3">
+
+          {/* Botón de abrir sidebar (solo móvil) */}
           <button
-            onClick={() => setNotificationsOpen(true)}
-            aria-label="Open notifications"
-            className="relative rounded-full p-2 bg-white shadow border border-gray-200 hover:bg-gray-50"
+            className="md:hidden bg-white rounded-full p-2 shadow border border-gray-200"
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Open sidebar"
           >
-            <Bell className="h-5 w-5 text-gray-700" />
-            {}
-            {hasUnread && (
-              <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-purple-500" />
-            )}
+            <Menu className="h-6 w-6 text-gray-700" />
           </button>
-        </header>
 
-        {}
+          {/* Icono de notificaciones */}
+          <NotificationBell />
+        </div>
+
         <main className="flex-1 overflow-auto">
           {children}
         </main>
-
-        {}
-        <NotificationDrawer
-          open={notificationsOpen}
-          onClose={() => setNotificationsOpen(false)}
-          notifications={notifications}
-          onNotificationClick={handleNotificationClick}
-        />
       </div>
     </div>
-  );
+  )
 }
+

--- a/src/app/(authed)/layout.tsx
+++ b/src/app/(authed)/layout.tsx
@@ -1,20 +1,70 @@
-"use client"
+"use client";
 
-import React, { useState } from "react"
-import { Sidebar } from "./sidebar"
-import { Menu } from 'lucide-react'
+import React, { useState } from "react";
+import { Sidebar } from "./sidebar";
+import { Menu, Bell } from "lucide-react";
+import { NotificationDrawer } from "@/components/ui/notificationDrawer";
+import { useRouter } from "next/navigation";
+import type { Notification } from "@/lib/types";
 
 type SurveyLayoutProps = {
-  children: React.ReactNode
-}
+  children: React.ReactNode;
+};
+
+const mockNotifications: Notification[] = [
+  {
+    id: 1,
+    message: "You were mentioned in RFC-123",
+    createdAt: "2025-11-27T10:00:00Z",
+    read: false,
+    targetUrl: "/rfc/123",
+  },
+  {
+    id: 2,
+    message: "RFC-234 was approved",
+    createdAt: "2025-11-27T09:30:00Z",
+    read: true,
+    targetUrl: "/rfc/234",
+  },
+  {
+    id: 3,
+    message: "ADR-56 was updated",
+    createdAt: "2025-11-27T08:15:00Z",
+    read: true,
+    targetUrl: "/adr/56",
+  },
+];
 
 export default function SurveyLayout({ children }: SurveyLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const [notifications, setNotifications] =
+    useState<Notification[]>(mockNotifications);
+
+  const router = useRouter();
+
+  const hasUnread = notifications.some((n) => !n.read);
+
+  const handleNotificationClick = (notification: Notification) => {
+    setNotifications((prev) =>
+      prev.map((n) =>
+        n.id === notification.id ? { ...n, read: true } : n
+      )
+    );
+
+    router.push(notification.targetUrl);
+
+    setNotificationsOpen(false);
+  };
 
   return (
-    <div className="flex h-screen bg-gray-50">
+    <div className="flex h-screen bg-white">
+      {}
       <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+
+      {}
       <div className="flex-1 flex flex-col relative">
+        {}
         <button
           className="absolute top-4 left-4 z-50 md:hidden bg-white rounded-full p-2 shadow border border-gray-200"
           onClick={() => setSidebarOpen(true)}
@@ -22,10 +72,35 @@ export default function SurveyLayout({ children }: SurveyLayoutProps) {
         >
           <Menu className="h-6 w-6 text-gray-700" />
         </button>
+
+        {}
+        <header className="hidden md:flex items-center justify-end px-6 py-4">
+          <button
+            onClick={() => setNotificationsOpen(true)}
+            aria-label="Open notifications"
+            className="relative rounded-full p-2 bg-white shadow border border-gray-200 hover:bg-gray-50"
+          >
+            <Bell className="h-5 w-5 text-gray-700" />
+            {}
+            {hasUnread && (
+              <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-purple-500" />
+            )}
+          </button>
+        </header>
+
+        {}
         <main className="flex-1 overflow-auto">
           {children}
         </main>
+
+        {}
+        <NotificationDrawer
+          open={notificationsOpen}
+          onClose={() => setNotificationsOpen(false)}
+          notifications={notifications}
+          onNotificationClick={handleNotificationClick}
+        />
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/ui/notificationBell.tsx
+++ b/src/components/ui/notificationBell.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Bell } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { NotificationDrawer } from "@/src/components/ui/notificationDrawer";
+import type { Notification } from "@/lib/types";
+import {
+    fetchNotifications,
+    fetchNotificationStatus,
+    markNotificationRead,
+    markAllNotificationsRead
+} from "@/lib/notifications";
+
+export function NotificationBell() {
+    const router = useRouter();
+    const [open, setOpen] = useState(false);
+    const [notifications, setNotifications] = useState<Notification[]>([]);
+    const [unreadCount, setUnreadCount] = useState(0);
+
+    const loadStatus = useCallback(async () => {
+        try {
+            const status = await fetchNotificationStatus();
+            // status.read es "hay notificaciones no leídas"
+            setUnreadCount(status.notisNotRead ?? 0);
+        } catch (e) {
+            console.error("Error loading notification status", e);
+        }
+    }, []);
+
+    const loadNotifications = useCallback(async () => {
+        try {
+            const items = await fetchNotifications({ size: 20 });
+            setNotifications(items);
+        } catch (e) {
+            console.error("Error loading notifications", e);
+        }
+    }, []);
+
+    useEffect(() => {
+        // Carga inicial
+        void loadStatus();
+
+        // Polling cada 30 segundos
+        const id = setInterval(() => {
+            void loadStatus();
+        }, 30000);
+
+        return () => clearInterval(id);
+    }, [loadStatus]);
+
+    const handleOpen = async () => {
+        if (!open) {
+            await loadNotifications();
+            setOpen(true);
+        } else {
+            setOpen(false);
+        }
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    const handleNotificationClick = async (n: Notification) => {
+        try {
+            if (!n.read) {
+                await markNotificationRead(n.id);
+                setNotifications((prev) =>
+                    prev.map((curr) =>
+                        curr.id === n.id ? { ...curr, read: true } : curr,
+                    ),
+                );
+                await loadStatus();
+            }
+
+            if (n.rfcId != null) {
+                router.push(`/rfc/${n.rfcId}`);
+                setOpen(false);
+            }
+        } catch (e) {
+            console.error("Error handling notification click", e);
+        }
+    };
+
+
+    const handleMarkAllRead = async () => {
+        try {
+            await markAllNotificationsRead()
+            setNotifications((prev) =>
+                prev.map((n) => ({ ...n, read: true }))
+            )
+            await loadStatus()
+        } catch (e) {
+            console.error("Error marking all as read", e)
+        }
+    }
+
+    const handleClearAll = () => {
+        setNotifications([])
+    }
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={handleOpen}
+                className="relative rounded-full p-2 bg-white shadow border border-gray-200 hover:bg-gray-50"
+                aria-label="Open notifications"
+            >
+                <Bell className="h-5 w-5 text-gray-700" />
+                {unreadCount > 0 && (
+                    <span className="absolute -top-1 -right-1 inline-flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] min-w-[16px] h-[16px] px-1">
+                        {unreadCount > 9 ? "9+" : unreadCount}
+                    </span>
+                )}
+            </button>
+
+            <NotificationDrawer
+                open={open}
+                onClose={handleClose}
+                notifications={notifications}
+                onNotificationClick={handleNotificationClick}
+                onMarkAllRead={handleMarkAllRead}
+                onClearAll={handleClearAll}
+            />
+
+        </>
+    );
+}

--- a/src/components/ui/notificationDrawer.tsx
+++ b/src/components/ui/notificationDrawer.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React from "react";
+import { X } from "lucide-react";
+import type { Notification } from "@/lib/types";
+
+type NotificationDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  notifications: Notification[];
+  onNotificationClick: (notification: Notification) => void;
+};
+
+function formatDate(iso: string) {
+  const date = new Date(iso);
+  return date.toLocaleString(); // luego se puede cambiar por "x minutes ago"
+}
+
+export function NotificationDrawer({
+  open,
+  onClose,
+  notifications,
+  onNotificationClick,
+}: NotificationDrawerProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      {/* Fondo semitransparente que oscurece TODO, incluido el sidebar */}
+      <div
+        className="flex-1 bg-black/30"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel lateral */}
+      <aside className="w-full max-w-md h-full bg-white shadow-xl flex flex-col">
+        {/* Cabecera */}
+        <div className="flex items-center justify-between px-6 py-4 border-b">
+          <h2 className="text-xl font-semibold">Notifications</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close notifications"
+            className="p-1 rounded-full hover:bg-gray-100"
+          >
+            <X className="h-5 w-5 text-gray-600" />
+          </button>
+        </div>
+
+        {/* Contenido */}
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+          {notifications.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              You have no notifications yet.
+            </p>
+          ) : (
+            notifications.map((n) => (
+              <button
+                key={n.id}
+                onClick={() => onNotificationClick(n)}
+                className={`w-full text-left rounded-xl border bg-white px-4 py-3 shadow-sm hover:shadow-md transition 
+                  ${
+                    !n.read
+                      ? "border-purple-300 bg-purple-50"
+                      : "border-gray-200"
+                  }`}
+              >
+                <p className="text-sm font-medium text-gray-900">
+                  {n.message}
+                </p>
+                <p className="text-xs text-gray-500 mt-1">
+                  {formatDate(n.createdAt)}
+                </p>
+              </button>
+            ))
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/ui/notificationDrawer.tsx
+++ b/src/components/ui/notificationDrawer.tsx
@@ -9,6 +9,8 @@ type NotificationDrawerProps = {
   onClose: () => void;
   notifications: Notification[];
   onNotificationClick: (notification: Notification) => void;
+  onMarkAllRead: () => void;
+  onClearAll: () => void;
 };
 
 function formatDate(iso: string) {
@@ -21,6 +23,8 @@ export function NotificationDrawer({
   onClose,
   notifications,
   onNotificationClick,
+  onMarkAllRead,
+  onClearAll,
 }: NotificationDrawerProps) {
   if (!open) return null;
 
@@ -38,14 +42,32 @@ export function NotificationDrawer({
         {/* Cabecera */}
         <div className="flex items-center justify-between px-6 py-4 border-b">
           <h2 className="text-xl font-semibold">Notifications</h2>
-          <button
-            onClick={onClose}
-            aria-label="Close notifications"
-            className="p-1 rounded-full hover:bg-gray-100"
-          >
-            <X className="h-5 w-5 text-gray-600" />
-          </button>
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onMarkAllRead}
+              className="text-sm text-purple-600 hover:underline"
+            >
+              Mark all read
+            </button>
+
+            <button
+              onClick={onClearAll}
+              className="text-sm text-gray-600 hover:underline"
+            >
+              Clear
+            </button>
+
+            <button
+              onClick={onClose}
+              aria-label="Close notifications"
+              className="p-1 rounded-full hover:bg-gray-100"
+            >
+              <X className="h-5 w-5 text-gray-600" />
+            </button>
+          </div>
         </div>
+
 
         {/* Contenido */}
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
@@ -59,10 +81,9 @@ export function NotificationDrawer({
                 key={n.id}
                 onClick={() => onNotificationClick(n)}
                 className={`w-full text-left rounded-xl border bg-white px-4 py-3 shadow-sm hover:shadow-md transition 
-                  ${
-                    !n.read
-                      ? "border-purple-300 bg-purple-50"
-                      : "border-gray-200"
+                  ${!n.read
+                    ? "border-purple-300 bg-purple-50"
+                    : "border-gray-200"
                   }`}
               >
                 <p className="text-sm font-medium text-gray-900">

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,78 @@
+import authFetch from "@/lib/fetcher"
+import type { Notification, NotificationStatus } from "@/lib/types"
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080"
+
+type PagedResponse = {
+  _embedded?: Record<string, Notification[]>
+  page?: {
+    number: number
+    size: number
+    totalElements: number
+    totalPages: number
+  }
+}
+
+export async function fetchNotifications(opts?: {
+  read?: boolean
+  page?: number
+  size?: number
+}): Promise<Notification[]> {
+  const params = new URLSearchParams()
+
+  if (typeof opts?.read === "boolean") {
+    params.append("read", String(opts.read))
+  }
+  params.append("page", String(opts?.page ?? 0))
+  params.append("size", String(opts?.size ?? 20))
+
+  const query = params.toString()
+  const url = `${API_BASE}/me/notifications${query ? `?${query}` : ""}`
+
+  const res = await authFetch(url)
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch notifications: ${res.status} ${res.statusText}`,
+    )
+  }
+
+  const data: PagedResponse = await res.json()
+
+  const embedded = data._embedded ?? {}
+  const firstKey = Object.keys(embedded)[0]
+  if (!firstKey) return []
+
+  return embedded[firstKey] ?? []
+}
+
+export async function fetchNotificationStatus(): Promise<NotificationStatus> {
+  const url = `${API_BASE}/me/notifications/status`
+  const res = await authFetch(url)
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch notification status: ${res.status} ${res.statusText}`,
+    )
+  }
+  return (await res.json()) as NotificationStatus
+}
+
+export async function markNotificationRead(id: number): Promise<void> {
+  const url = `${API_BASE}/me/notifications/${id}/read`
+  const res = await authFetch(url, { method: "PATCH" })
+  if (!res.ok) {
+    throw new Error(
+      `Failed to mark notification as read: ${res.status} ${res.statusText}`,
+    )
+  }
+}
+
+export async function markAllNotificationsRead(): Promise<void> {
+  const url = `${API_BASE}/me/notifications/mark-all-read`
+  const res = await authFetch(url, { method: "POST" })
+  if (!res.ok) {
+    throw new Error(
+      `Failed to mark all notifications as read: ${res.status} ${res.statusText}`,
+    )
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,3 +29,12 @@ export interface Comment {
     updatedAt: string | null
     replies: Comment[]
 }
+
+export interface Notification {
+  id: number;
+  message: string;
+  createdAt: string;   
+  read: boolean;
+  targetUrl: string;   
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,11 +30,27 @@ export interface Comment {
     replies: Comment[]
 }
 
+export type NotificationType =
+  | "MENTION"
+  | "RFC_UPDATE"
+  | "APP_NOTIFICATION"
+  | "OTHER"
+
 export interface Notification {
-  id: number;
-  message: string;
-  createdAt: string;   
-  read: boolean;
-  targetUrl: string;   
+  id: number
+  type: NotificationType
+  message: string
+  details: string | null
+  createdAt: string
+  read: boolean
+  commentId: number | null
+  rfcId: number | null
+}
+
+// OJO: en backend el campo `read` es en realidad
+// `areThereNotReadNotis(...)` => "hay no leídas"
+export interface NotificationStatus {
+  read: boolean
+  notisNotRead: number
 }
 


### PR DESCRIPTION
Added notification panel that recieves notifications sent by the backend (checks if there are any new notifications every 30 seconds).

It also includes 2 buttons:
- Mark as read 
- Clear (not functional yet because there is no delete in the backend)

When a notification is clicked it takes you to the corresponding rfc where the action has happened (either closing an rfc, adding an alternative or being mentioned in the discussion) and the status of the notification is changed from not read to read.